### PR TITLE
Add support for Rating fields

### DIFF
--- a/lib/itunes/track.rb
+++ b/lib/itunes/track.rb
@@ -68,6 +68,18 @@ module ITunes
     def rating
       self['Rating']
     end
+
+    def rating_computed?
+      self['Rating Computed'] || false
+    end
+
+    def album_rating
+      self['Album Rating']
+    end
+
+    def album_rating_computed?
+      self['Album Rating Computed'] || false
+    end
     
     def play_count
       self['Play Count'] || 0

--- a/lib/itunes/track.rb
+++ b/lib/itunes/track.rb
@@ -64,6 +64,10 @@ module ITunes
     def last_played_at
       self['Play Date UTC']
     end
+
+    def rating
+      self['Rating']
+    end
     
     def play_count
       self['Play Count'] || 0

--- a/test/fixtures/iTunes Library.xml
+++ b/test/fixtures/iTunes Library.xml
@@ -2636,6 +2636,9 @@
 			<key>Play Date</key><integer>3354942706</integer>
 			<key>Play Date UTC</key><date>2010-04-24T13:31:46Z</date>
 			<key>Rating</key><integer>80</integer>
+			<key>Rating Computed</key><true/>
+			<key>Album Rating</key><integer>60</integer>
+			<key>Album Rating Computed</key><true/>
 			<key>Release Date</key><date>2010-04-23T17:00:00Z</date>
 			<key>Artwork Count</key><integer>1</integer>
 			<key>Persistent ID</key><string>2BB48776F65C1CB3</string>

--- a/test/fixtures/iTunes Library.xml
+++ b/test/fixtures/iTunes Library.xml
@@ -2635,6 +2635,7 @@
 			<key>Play Count</key><integer>1</integer>
 			<key>Play Date</key><integer>3354942706</integer>
 			<key>Play Date UTC</key><date>2010-04-24T13:31:46Z</date>
+			<key>Rating</key><integer>80</integer>
 			<key>Release Date</key><date>2010-04-23T17:00:00Z</date>
 			<key>Artwork Count</key><integer>1</integer>
 			<key>Persistent ID</key><string>2BB48776F65C1CB3</string>

--- a/test/test_itunes.rb
+++ b/test/test_itunes.rb
@@ -86,6 +86,11 @@ class TestITunes < Test::Unit::TestCase
     assert_equal nil, library.fetch_track(7944).last_played_at # unplayed track
   end
 
+  def test_rating
+    assert_equal nil, library.fetch_track(7944).rating
+    assert_equal 80, library.fetch_track(10973).rating
+  end
+
   def test_track_play_count
     assert_equal 0, library.fetch_track(7944).play_count
   end

--- a/test/test_itunes.rb
+++ b/test/test_itunes.rb
@@ -91,6 +91,21 @@ class TestITunes < Test::Unit::TestCase
     assert_equal 80, library.fetch_track(10973).rating
   end
 
+  def test_rating_computed
+    assert_equal false, library.fetch_track(7944).rating_computed?
+    assert_equal true, library.fetch_track(10973).rating_computed?
+  end
+
+  def test_album_rating
+    assert_equal nil, library.fetch_track(7944).album_rating
+    assert_equal 60, library.fetch_track(10973).album_rating
+  end
+
+  def test_album_rating_computed
+    assert_equal false, library.fetch_track(7944).album_rating_computed?
+    assert_equal true, library.fetch_track(10973).album_rating_computed?
+  end
+
   def test_track_play_count
     assert_equal 0, library.fetch_track(7944).play_count
   end


### PR DESCRIPTION
This change adds support for the Rating, Album Rating, and corresponding "computed" fields. (The computed fields indicate that the rating was not set by the user but calculated from other sources, e.g. an album rating can be computed based on its songs' ratings, or vice versa).

I no longer use iTunes, but I still have my library file with over 13,000 songs, and I wanted to be able to transfer some of that information to other formats. I updated this code so that I could extract the ratings into a CSV file using the related itunes-csv repo.

Tested: built gem, ran unit tests, ran the code on my own library file