### PR TITLE
Add more track fields

### DIFF
--- a/lib/itunes/track.rb
+++ b/lib/itunes/track.rb
@@ -89,6 +89,10 @@ module ITunes
       self['Total Time'] / 1000
     end
 
+    def duration_ms
+      self['Total Time'] ? self['Total Time'] : nil
+    end
+
     def kind
       self['Kind']
     end

--- a/lib/itunes/track.rb
+++ b/lib/itunes/track.rb
@@ -41,16 +41,20 @@ module ITunes
       self['Genre']
     end
 
-    def bpm
-      self['BPM']
-    end
-
     def year
       self['Year']
     end
 
     def composer
       self['Composer']
+    end
+
+    def season_number
+      self['Season']
+    end
+
+    def episode_number
+      self['Episode Order']
     end
 
     def date_added
@@ -81,16 +85,8 @@ module ITunes
       self['Play Count'] || 0
     end
 
-    def skip_count
-      self['Skip Count'] || 0
-    end
-
-    def duration_sec
-      self['Total Time'] ? self['Total Time'] / 1000 : nil
-    end
-
-    def duration_ms
-      self['Total Time'] ? self['Total Time'] : nil
+    def total_time
+      self['Total Time'] / 1000
     end
 
     def kind
@@ -107,10 +103,6 @@ module ITunes
     
     def artwork_count
       self['Artwork Count']
-    end
-
-    def comment
-      self['Comments']
     end
 
     def location

--- a/lib/itunes/track.rb
+++ b/lib/itunes/track.rb
@@ -126,6 +126,10 @@ module ITunes
       uri_parser.unescape(location).gsub('file://localhost', '')
     end
 
+    def comments
+      self['Comments']
+    end
+
     def audio?
       !video?
     end

--- a/lib/itunes/track.rb
+++ b/lib/itunes/track.rb
@@ -41,20 +41,16 @@ module ITunes
       self['Genre']
     end
 
+    def bpm
+      self['BPM']
+    end
+
     def year
       self['Year']
     end
 
     def composer
       self['Composer']
-    end
-
-    def season_number
-      self['Season']
-    end
-
-    def episode_number
-      self['Episode Order']
     end
 
     def date_added
@@ -85,6 +81,10 @@ module ITunes
       self['Play Count'] || 0
     end
 
+    def skip_count
+      self['Skip Count'] || 0
+    end
+
     def total_time
       self['Total Time'] / 1000
     end
@@ -103,6 +103,10 @@ module ITunes
     
     def artwork_count
       self['Artwork Count']
+    end
+
+    def comment
+      self['Comments']
     end
 
     def location

--- a/lib/itunes/track.rb
+++ b/lib/itunes/track.rb
@@ -41,6 +41,10 @@ module ITunes
       self['Genre']
     end
 
+    def bpm
+      self['BPM']
+    end
+
     def year
       self['Year']
     end

--- a/lib/itunes/track.rb
+++ b/lib/itunes/track.rb
@@ -89,6 +89,10 @@ module ITunes
       self['Play Count'] || 0
     end
 
+    def skip_count
+      self['Skip Count'] || 0
+    end
+
     def total_time
       self['Total Time'] / 1000
     end

--- a/lib/itunes/track.rb
+++ b/lib/itunes/track.rb
@@ -85,8 +85,8 @@ module ITunes
       self['Skip Count'] || 0
     end
 
-    def total_time
-      self['Total Time'] / 1000
+    def duration_sec
+      self['Total Time'] ? self['Total Time'] / 1000 : nil
     end
 
     def kind

--- a/lib/itunes/track.rb
+++ b/lib/itunes/track.rb
@@ -94,7 +94,11 @@ module ITunes
     end
 
     def total_time
-      self['Total Time'] / 1000
+      self['Total Time'] / 1000 
+    end
+
+    def duration_ms
+      self['Total Time'] ? self['Total Time'] : nil
     end
 
     def kind

--- a/lib/itunes/track.rb
+++ b/lib/itunes/track.rb
@@ -94,7 +94,7 @@ module ITunes
     end
 
     def total_time
-      self['Total Time'] / 1000 
+      self['Total Time'] ? self['Total Time'] / 1000 : nil
     end
 
     def duration_ms

--- a/test/fixtures/iTunes Library.xml
+++ b/test/fixtures/iTunes Library.xml
@@ -2969,6 +2969,74 @@
 			<key>File Folder Count</key><integer>5</integer>
 			<key>Library Folder Count</key><integer>1</integer>
 		</dict>
+		<key>11083</key>
+		<dict>
+			<key>Track ID</key><integer>11083</integer>
+			<key>Name</key><string>I Still Haven't Found What I'm Looking For</string>
+			<key>Artist</key><string>U2</string>
+			<key>Composer</key><string>U2</string>
+			<key>Album</key><string>The Joshua Tree</string>
+			<key>Genre</key><string>Rock</string>
+			<key>Kind</key><string>MPEG audio file</string>
+			<key>Size</key><integer>5574172</integer>
+			<key>Total Time</key><integer>278595</integer>
+			<key>Disc Number</key><integer>1</integer>
+			<key>Disc Count</key><integer>1</integer>
+			<key>Track Number</key><integer>2</integer>
+			<key>Track Count</key><integer>11</integer>
+			<key>Year</key><integer>1987</integer>
+			<key>BPM</key><integer>192</integer>
+			<key>Date Modified</key><date>2007-12-08T03:11:46Z</date>
+			<key>Date Added</key><date>2008-07-27T00:53:02Z</date>
+			<key>Bit Rate</key><integer>160</integer>
+			<key>Sample Rate</key><integer>44100</integer>
+			<key>Play Count</key><integer>2</integer>
+			<key>Play Date</key><integer>3345891711</integer>
+			<key>Play Date UTC</key><date>2010-01-09T19:21:51Z</date>
+			<key>Skip Count</key><integer>1</integer>
+			<key>Skip Date</key><date>2009-03-10T00:53:20Z</date>
+			<key>Album Rating</key><integer>60</integer>
+			<key>Album Rating Computed</key><true/>
+			<key>Normalization</key><integer>1149</integer>
+			<key>Sort Album</key><string>Joshua Tree</string>
+			<key>Persistent ID</key><string>36990211F06BD416</string>
+			<key>Track Type</key><string>File</string>
+			<key>Location</key><string>file:///localhost/iTunes/iTunes%20Music/Music/U2/The%20Joshua%20Tree/02%20I%20Still%20Haven't%20Found%20What%20I'm%20Looking%20For.mp3</string>
+			<key>File Folder Count</key><integer>5</integer>
+			<key>Library Folder Count</key><integer>1</integer>
+		</dict>
+		<key>11084</key>
+		<dict>
+			<key>Track ID</key><integer>11084</integer>
+			<key>Name</key><string>Brand New Colony</string>
+			<key>Artist</key><string>The Postal Service</string>
+			<key>Album</key><string>Give Up</string>
+			<key>Genre</key><string>Indie</string>
+			<key>Kind</key><string>AAC audio file</string>
+			<key>Size</key><integer>4103805</integer>
+			<key>Total Time</key><integer>253026</integer>
+			<key>Track Number</key><integer>9</integer>
+			<key>Date Modified</key><date>2010-01-26T16:16:31Z</date>
+			<key>Date Added</key><date>2008-07-27T00:53:21Z</date>
+			<key>Bit Rate</key><integer>128</integer>
+			<key>Sample Rate</key><integer>44100</integer>
+			<key>Comments</key><string>Sub Pop</string>
+			<key>Play Count</key><integer>18</integer>
+			<key>Play Date</key><integer>3445454755</integer>
+			<key>Play Date UTC</key><date>2013-03-07T03:45:55Z</date>
+			<key>Skip Count</key><integer>3</integer>
+			<key>Skip Date</key><date>2010-01-26T22:05:53Z</date>
+			<key>Rating</key><integer>40</integer>
+			<key>Album Rating</key><integer>40</integer>
+			<key>Album Rating Computed</key><true/>
+			<key>Normalization</key><integer>2327</integer>
+			<key>Sort Artist</key><string>Postal Service</string>
+			<key>Persistent ID</key><string>36990211F06BD713</string>
+			<key>Track Type</key><string>File</string>
+			<key>Location</key><string>file:///localhost/Music/iTunes/iTunes%20Music/Music/The%20Postal%20Service/Give%20Up/09%20Brand%20New%20Colony.m4a</string>
+			<key>File Folder Count</key><integer>5</integer>
+			<key>Library Folder Count</key><integer>1</integer>
+		</dict>
 	</dict>
 	<key>Playlists</key>
 	<array>

--- a/test/test_itunes.rb
+++ b/test/test_itunes.rb
@@ -73,6 +73,10 @@ class TestITunes < Test::Unit::TestCase
     assert_equal "Rock", library.fetch_track(7944).genre
   end
 
+  def test_bpm
+    assert_equal "192", library.fetch_track(11083).bpm
+  end
+
   def test_track_year
     assert_equal 2009, library.fetch_track(7944).year
   end
@@ -110,6 +114,10 @@ class TestITunes < Test::Unit::TestCase
     assert_equal 0, library.fetch_track(7944).play_count
   end
 
+  def test_track_skip_count
+    assert_equal 3, library.fetch_track(11084).skip_count
+  end
+
   def test_track_unplayed
     assert_equal true, library.fetch_track(7944).unplayed?
   end
@@ -128,6 +136,10 @@ class TestITunes < Test::Unit::TestCase
     assert_equal expected_path, library.fetch_track(7405).location_path
   end
 
+  def test_track_comments
+    assert_equal "Sub Pop", library.fetch_track(11084).comments
+  end
+
   def test_track_location_path_is_nil_if_location_not_present
     assert_nil library.fetch_track(7400).location_path
   end
@@ -142,6 +154,10 @@ class TestITunes < Test::Unit::TestCase
 
   def test_artwork_count
     assert_equal 1, library.fetch_track(7949).artwork_count
+  end
+
+  def test_duration_ms
+    assert_equal 246909, library.fetch_track(7944).duration_ms
   end
 
   def test_audio_track_total_time


### PR DESCRIPTION
Add options for additional track fields:

* bpm
* comments
* skip_count

Also adds `duration_ms` to extract an undivided total_time, and adds handling for when the Total Time key is missing in an iTunes library.

All of these have been tested locally. Who knows why I had a track key missing a duration, but mysteries abound.

I noticed the file wasn't in alphabetical order so I roughly judged the semantic relevance of the new fields I was adding and placed them there.

Added test cases for the new fields:
* bpm
* comments
* duration_ms
* skip_count

Including 2 new tracks from my iTunes Library with the valid metadata required to test the fields.